### PR TITLE
listBans always returns empty array

### DIFF
--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -401,7 +401,8 @@ export class GotCFToolsClient implements CFToolsClient {
 
     async listBans(request: ListBansRequest): Promise<Ban[]> {
         const response = await this.client.get<GetBanResponse>(`v1/banlist/${request.list.id}/bans`, {
-            searchParams: {
+            allowGetBody: true,
+            json: {
                 filter: request.playerId.id
             },
             context: {

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -401,9 +401,8 @@ export class GotCFToolsClient implements CFToolsClient {
 
     async listBans(request: ListBansRequest): Promise<Ban[]> {
         const response = await this.client.get<GetBanResponse>(`v1/banlist/${request.list.id}/bans`, {
-            allowGetBody: true,
-            json: {
-                filter: request.playerId.id
+            searchParams: {
+                filter: (await this.resolve(request)).id,
             },
             context: {
                 authorization: await this.auth!.provide(),


### PR DESCRIPTION
### **[GET]** _/v1/banlist/{banlist_id}/bans_  
For some reason accepts data only as body. This is a weird implementation for a **GET** endpoint. This was kinda tricky to figure out because if you send `filter` as a query parameter, the server would still respond with a `200 OK`. However, the response will be always empty.

With Query Parameter:
![Capture](https://user-images.githubusercontent.com/42031273/164999881-a361adbd-48fc-4652-87dc-613679b9ca98.JPG)

With JSON Body:
![Capture2](https://user-images.githubusercontent.com/42031273/164999897-44b004e9-14eb-4236-b3fd-32436e184aeb.JPG)


Reference:
[https://github.com/sindresorhus/got/commit/526b4bb03eed5196a3c6375beeb7699e8f512d4f](url)
