### PR TITLE
feat: delete player statistics

### DIFF
--- a/src/internal/caching-cftools-client.spec.ts
+++ b/src/internal/caching-cftools-client.spec.ts
@@ -1,6 +1,7 @@
 import {
     Banlist,
     CFToolsClient, CFToolsId,
+    DeletePlayerDetailsRequest,
     Game,
     GameServerItem, GameSession,
     GetLeaderboardRequest,
@@ -24,6 +25,7 @@ describe('CachingCFToolsClient', () => {
             getGameServerDetails: jest.fn(),
             getLeaderboard: jest.fn(),
             getPlayerDetails: jest.fn(),
+            deletePlayerDetails: jest.fn(),
             getPriorityQueue: jest.fn(),
             putPriorityQueue: jest.fn(),
             deletePriorityQueue: jest.fn(),
@@ -86,6 +88,18 @@ describe('CachingCFToolsClient', () => {
             expect(stubClient.getPlayerDetails).toHaveBeenCalledTimes(1);
             expect(firstResponse).toEqual(secondResponse);
         });
+
+        it('deletePlayerDetails', async () => {
+            stubClient.deletePlayerDetails = jest.fn(() => Promise.resolve());
+            const request: DeletePlayerDetailsRequest = {
+                playerId: SteamId64.of('123456789'),
+            };
+            const firstResponse = await client.deletePlayerDetails(request);
+            const secondResponse = await client.deletePlayerDetails(SteamId64.of('123456789'));
+
+            expect(stubClient.deletePlayerDetails).toHaveBeenCalledTimes(2);
+            expect(firstResponse).toEqual(secondResponse);
+        })
 
         it('getPriorityQueue', async () => {
             stubClient.getPriorityQueue = jest.fn(() => Promise.resolve({

--- a/src/internal/caching-cftools-client.ts
+++ b/src/internal/caching-cftools-client.ts
@@ -12,6 +12,7 @@ import {
     GetGameServerDetailsRequest,
     GetLeaderboardRequest,
     GetPlayerDetailsRequest,
+    DeletePlayerDetailsRequest,
     GetPriorityQueueRequest,
     GetWhitelistRequest,
     LeaderboardItem,
@@ -93,6 +94,10 @@ export class CachingCFToolsClient implements CFToolsClient {
     getPlayerDetails(id: GenericId | GetPlayerDetailsRequest): Promise<Player> {
         const key = `${this.serverApiId(id).id}:${playerId(id).id}`;
         return this.cacheOrDefault('playerDetails', key, () => this.client.getPlayerDetails(id));
+    }
+
+    deletePlayerDetails(id: GenericId | DeletePlayerDetailsRequest): Promise<void> {
+        return this.client.deletePlayerDetails(id);
     }
 
     getPriorityQueue(id: GenericId | GetPriorityQueueRequest): Promise<PriorityQueueItem | null> {

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -21,6 +21,7 @@ import {
     GetGameServerDetailsRequest,
     GetLeaderboardRequest,
     GetPlayerDetailsRequest,
+    DeletePlayerDetailsRequest,
     GetPriorityQueueRequest,
     GetServerInfoRequest,
     GetWhitelistRequest,
@@ -129,6 +130,19 @@ export class GotCFToolsClient implements CFToolsClient {
                 cftools: id
             }
         };
+    }
+
+    async deletePlayerDetails(id: GenericId | DeletePlayerDetailsRequest): Promise<void> {
+        this.assertAuthentication();
+        const cftoolsId = await this.resolve(id);
+        await this.client.delete(`v2/server/${this.resolveServerApiId('serverApiId' in id ? id : undefined).id}/player`, {
+            searchParams: {
+                cftools_id: cftoolsId.id,
+            },
+            context: {
+                authorization: await this.auth!.provide(this.client),
+            },
+        });
     }
 
     async getLeaderboard(request: GetLeaderboardRequest): Promise<LeaderboardItem[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,14 @@ export interface CFToolsClient {
     getPlayerDetails(id: GenericId | GetPlayerDetailsRequest): Promise<Player>
 
     /**
+     * Deletes the player details of the requested player. This will remove all information about the player from the
+     * CFTools Cloud database. This action is irreversible.
+     * 
+     * This request requires an authenticated client.
+     */
+    deletePlayerDetails(id: GenericId | DeletePlayerDetailsRequest): Promise<void>
+
+    /**
      * Creates a leaderboard based on the requested statistic in the requested order.
      * The fields of an individual leaderboard item may vary based on the requested base statistics.
      *
@@ -393,6 +401,9 @@ interface IdRequest extends OverrideServerApiId {
 }
 
 export interface GetPlayerDetailsRequest extends IdRequest {
+}
+
+export interface DeletePlayerDetailsRequest extends IdRequest {
 }
 
 export interface GetPriorityQueueRequest extends IdRequest {


### PR DESCRIPTION
This commit implements the `[DELETE] /v2/server/{server_api_id}/player` endpoint, which deletes player statistics.