### PR TITLE
feat: Fetch application grants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cftools-sdk",
-  "version": "1.9.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cftools-sdk",
-      "version": "1.9.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "got": "^11.8.5"

--- a/src/internal/builder.ts
+++ b/src/internal/builder.ts
@@ -13,6 +13,7 @@ export class CFToolsClientBuilder {
     private credentials: LoginCredentials | undefined;
     private cache: Cache | undefined;
     private cacheConfig: CacheConfiguration = {
+        appGrants: 60,
         leaderboard: 30,
         serverInfo: 30,
         gameSessions: 10,

--- a/src/internal/caching-cftools-client.spec.ts
+++ b/src/internal/caching-cftools-client.spec.ts
@@ -22,6 +22,7 @@ describe('CachingCFToolsClient', () => {
 
     beforeEach(() => {
         stubClient = {
+            getAppGrants: jest.fn(),
             getGameServerDetails: jest.fn(),
             getLeaderboard: jest.fn(),
             getPlayerDetails: jest.fn(),
@@ -46,6 +47,7 @@ describe('CachingCFToolsClient', () => {
             healPlayer: jest.fn(),
         };
         client = new CachingCFToolsClient(new InMemoryCache(), {
+            appGrants: 60,
             priorityQueue: 30,
             gameSessions: 10,
             serverInfo: 30,
@@ -59,6 +61,18 @@ describe('CachingCFToolsClient', () => {
     });
 
     describe('caches', () => {
+        it('getAppGrants', async () => {
+            stubClient.getAppGrants = jest.fn(() => Promise.resolve({
+                server: [],
+                banlist: []
+            }));
+            const firstResponse = await client.getAppGrants();
+            const secondResponse = await client.getAppGrants();
+
+            expect(stubClient.getAppGrants).toHaveBeenCalledTimes(1);
+            expect(firstResponse).toEqual(secondResponse);
+        })
+
         it('getGameServerDetails', async () => {
             stubClient.getGameServerDetails = jest.fn(() => Promise.resolve({
                 name: 'someName'

--- a/src/internal/caching-cftools-client.ts
+++ b/src/internal/caching-cftools-client.ts
@@ -29,7 +29,8 @@ import {
     GetServerInfoRequest,
     ListGameSessionsRequest,
     GameSession,
-    SpawnItemRequest, TeleportPlayerRequest, CFToolsId, GameLabsActionRequest, HealPlayerRequest, KillPlayerRequest
+    SpawnItemRequest, TeleportPlayerRequest, CFToolsId, GameLabsActionRequest, HealPlayerRequest, KillPlayerRequest,
+    AppGrants
 } from '../types';
 
 function playerId(id: GenericId | { playerId: GenericId }): GenericId {
@@ -49,6 +50,11 @@ export class CachingCFToolsClient implements CFToolsClient {
         private readonly client: CFToolsClient,
         private readonly defaultServerApiId?: ServerApiId
     ) {
+    }
+
+    getAppGrants(): Promise<AppGrants> {
+        const key = 'appGrants';
+        return this.cacheOrDefault('appGrants', key, () => this.client.getAppGrants());
     }
 
     getGameServerDetails(request: GetGameServerDetailsRequest): Promise<GameServerItem> {

--- a/src/internal/caching-cftools-client.ts
+++ b/src/internal/caching-cftools-client.ts
@@ -1,4 +1,5 @@
 import {
+    AppGrants,
     Ban,
     Cache,
     CacheConfiguration,
@@ -30,7 +31,6 @@ import {
     ListGameSessionsRequest,
     GameSession,
     SpawnItemRequest, TeleportPlayerRequest, CFToolsId, GameLabsActionRequest, HealPlayerRequest, KillPlayerRequest,
-    AppGrants
 } from '../types';
 
 function playerId(id: GenericId | { playerId: GenericId }): GenericId {

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -1,8 +1,10 @@
 import {
     AmbiguousDeleteBanRequest,
+    AppGrants,
     AuthenticationRequired,
     AuthorizationProvider,
     Ban,
+    BaseResource,
     BattlEyeGUID,
     BohemiaInteractiveId,
     CFToolsClient,
@@ -41,12 +43,11 @@ import {
     ServerApiId,
     ServerApiIdRequired,
     ServerInfo,
+    ServerResource,
     SpawnItemRequest,
     SteamId64,
     TeleportPlayerRequest,
     WhitelistItem,
-    AppGrants,
-    RawAppGrants
 } from '../../types';
 import {HttpClient} from '../http';
 import {URLSearchParams} from 'url';
@@ -64,6 +65,22 @@ import {
     toHitZones
 } from './types';
 import {asDate} from './date-to-string';
+
+interface RawBanListAppGrant {
+    created_at: string,
+    resource: BaseResource,
+}
+
+interface RawServerAppGrant {
+    created_at: string,
+    resource: ServerResource,
+}
+
+interface RawAppGrants {
+    status: boolean;
+    banlist: RawBanListAppGrant[],
+    server: RawServerAppGrant[],
+}
 
 export class GotCFToolsClient implements CFToolsClient {
     private readonly auth?: AuthorizationProvider;

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -44,7 +44,9 @@ import {
     SpawnItemRequest,
     SteamId64,
     TeleportPlayerRequest,
-    WhitelistItem
+    WhitelistItem,
+    AppGrants,
+    RawAppGrants
 } from '../../types';
 import {HttpClient} from '../http';
 import {URLSearchParams} from 'url';
@@ -69,6 +71,27 @@ export class GotCFToolsClient implements CFToolsClient {
     constructor(private client: HttpClient, private serverApiId?: ServerApiId, auth?: AuthorizationProvider) {
         if (auth) {
             this.auth = auth;
+        }
+    }
+
+    async getAppGrants(): Promise<AppGrants> {
+        this.assertAuthentication();
+        const response = await this.client.get<RawAppGrants>('v1/@app/grants', {
+            context: {
+                authorization: await this.auth!.provide(this.client),
+            },
+        });
+        return {
+            banlist: response.banlist?.map((e) => ({
+                ...e,
+                created: new Date(e.created_at),
+                created_at: undefined
+            })) ?? [],
+            server: response.server?.map((e) => ({
+                ...e,
+                created: new Date(e.created_at),
+                created_at: undefined
+            })) ?? [],
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,12 @@ import {HttpClient} from './internal/http';
 
 export interface CFToolsClient {
     /**
+     * Returns a list of CFTools resources that have authorized the application to access them.
+     * 
+     * This request requires an authenticated client.
+     */
+    getAppGrants(): Promise<AppGrants>
+    /**
      * Returns metadata about an individual player.
      *
      * This request requires an authenticated client.
@@ -284,6 +290,7 @@ export class EnterpriseAuthorization implements Authorization {
  * can execute. The value specifies the time in seconds the result of the action should be cached.
  */
 export interface CacheConfiguration {
+    appGrants: number,
     gameServerDetails: number,
     serverInfo: number,
     gameSessions: number,
@@ -394,6 +401,47 @@ export enum Statistic {
      * @deprecated Use Statistic.KILL_DEATH_RATIO instead
      */
     KILL_DEATH_RATION = 'kdratio',
+}
+
+export interface AppGrants {
+    banlist: BanListAppGrant[],
+    server: ServerAppGrant[],
+}
+
+export interface BaseResource {
+    id: string,
+    identifier: string,
+    object_id: string,
+}
+
+export interface ServerResource extends BaseResource {
+    gameserver_id: string,
+}
+
+export interface RawBanListAppGrant {
+    created_at: string,
+    resource: BaseResource,
+}
+
+export interface RawServerAppGrant {
+    created_at: string,
+    resource: ServerResource,
+}
+
+export interface RawAppGrants {
+    status: boolean;
+    banlist: RawBanListAppGrant[],
+    server: RawServerAppGrant[],
+}
+
+export interface BanListAppGrant {
+    created: Date,
+    resource: BaseResource,
+}
+
+export interface ServerAppGrant {
+    created: Date,
+    resource: ServerResource,
 }
 
 interface IdRequest extends OverrideServerApiId {

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,47 +403,6 @@ export enum Statistic {
     KILL_DEATH_RATION = 'kdratio',
 }
 
-export interface AppGrants {
-    banlist: BanListAppGrant[],
-    server: ServerAppGrant[],
-}
-
-export interface BaseResource {
-    id: string,
-    identifier: string,
-    object_id: string,
-}
-
-export interface ServerResource extends BaseResource {
-    gameserver_id: string,
-}
-
-export interface RawBanListAppGrant {
-    created_at: string,
-    resource: BaseResource,
-}
-
-export interface RawServerAppGrant {
-    created_at: string,
-    resource: ServerResource,
-}
-
-export interface RawAppGrants {
-    status: boolean;
-    banlist: RawBanListAppGrant[],
-    server: RawServerAppGrant[],
-}
-
-export interface BanListAppGrant {
-    created: Date,
-    resource: BaseResource,
-}
-
-export interface ServerAppGrant {
-    created: Date,
-    resource: ServerResource,
-}
-
 interface IdRequest extends OverrideServerApiId {
     playerId: GenericId,
 }
@@ -1045,4 +1004,25 @@ export class AmbiguousDeleteBanRequest extends Error {
         super('AmbiguousDeleteBanRequest');
         Object.setPrototypeOf(this, AmbiguousDeleteBanRequest.prototype);
     }
+}
+
+export interface BaseResource {
+    id: string,
+    identifier: string,
+    object_id: string,
+}
+
+export interface ServerResource extends BaseResource {
+    gameserver_id: string,
+}
+
+export interface AppGrants {
+    banlist: {
+        created: Date,
+        resource: BaseResource,
+    }[],
+    server: {
+        created: Date,
+        resource: ServerResource,
+    }[],
 }


### PR DESCRIPTION
This pull requests implement the `/v1/@app/grants` endpoint. This endpoint allows you to check which resources (servers and banlists) have authorized the client/application to perform actions on the resource through the API.

Please note: Jest runners haven't been implemented for this request, as I'm unsure of the environment and grants of the connected test runner app/credentials. The caching configuration does have a test added.