### PR TITLE
Support for the Account Creation API

### DIFF
--- a/src/internal/builder.ts
+++ b/src/internal/builder.ts
@@ -127,7 +127,7 @@ export class CFToolsClientBuilder {
         } else {
             auth = new NoOpAuthorizationProvider();
         }
-        const client = new GotCFToolsClient(this.clientBuilder(auth), this.serverApiId, this.enterpriseToken, this.hasAccountCreationAccess, auth);
+        const client = new GotCFToolsClient(this.clientBuilder(auth), this.serverApiId, this.hasAccountCreationAccess, auth);
         if (this.cache !== undefined) {
             return new CachingCFToolsClient(this.cache, this.cacheConfig, client, this.serverApiId);
         }

--- a/src/internal/builder.ts
+++ b/src/internal/builder.ts
@@ -10,7 +10,6 @@ export type HttpClientBuilder = (auth?: AuthorizationProvider) => HttpClient;
 export class CFToolsClientBuilder {
     private serverApiId: ServerApiId | undefined;
     private enterpriseToken: string | undefined;
-    private hasAccountCreationAccess: boolean | undefined;
     private credentials: LoginCredentials | undefined;
     private cache: Cache | undefined;
     private cacheConfig: CacheConfiguration = {
@@ -48,20 +47,6 @@ export class CFToolsClientBuilder {
      */
     public withEnterpriseApi(token: string): CFToolsClientBuilder {
         this.enterpriseToken = token;
-        return this;
-    }
-
-    /**
-     * The Enterprise API comes with special endpoint parameter for `/v1/users/resolve` (`client#resolve`), which allows to
-     * create a new CFTools account for an identity token that has never played on a CFTools Cloud-enabled server before.
-     * This functionality is not available to everyone with an Enterprise API token, but requires explicit access by CFTools.
-     * @param status Whether to enable the account creation API
-     */
-    public withAccountCreationAPI(status: boolean): CFToolsClientBuilder {
-        this.hasAccountCreationAccess = status;
-        if (this.hasAccountCreationAccess && !this.enterpriseToken) {
-            throw new Error('Account creation API requires an Enterprise API access token');
-        }
         return this;
     }
 
@@ -127,7 +112,7 @@ export class CFToolsClientBuilder {
         } else {
             auth = new NoOpAuthorizationProvider();
         }
-        const client = new GotCFToolsClient(this.clientBuilder(auth), this.serverApiId, this.hasAccountCreationAccess, auth);
+        const client = new GotCFToolsClient(this.clientBuilder(auth), this.serverApiId, auth);
         if (this.cache !== undefined) {
             return new CachingCFToolsClient(this.cache, this.cacheConfig, client, this.serverApiId);
         }

--- a/src/internal/builder.ts
+++ b/src/internal/builder.ts
@@ -10,6 +10,7 @@ export type HttpClientBuilder = (auth?: AuthorizationProvider) => HttpClient;
 export class CFToolsClientBuilder {
     private serverApiId: ServerApiId | undefined;
     private enterpriseToken: string | undefined;
+    private hasAccountCreationAccess: boolean | undefined;
     private credentials: LoginCredentials | undefined;
     private cache: Cache | undefined;
     private cacheConfig: CacheConfiguration = {
@@ -47,6 +48,20 @@ export class CFToolsClientBuilder {
      */
     public withEnterpriseApi(token: string): CFToolsClientBuilder {
         this.enterpriseToken = token;
+        return this;
+    }
+
+    /**
+     * The Enterprise API comes with special endpoint parameter for `/v1/users/resolve` (`client#resolve`), which allows to
+     * create a new CFTools account for an identity token that has never played on a CFTools Cloud-enabled server before.
+     * This functionality is not available to everyone with an Enterprise API token, but requires explicit access by CFTools.
+     * @param status Whether to enable the account creation API
+     */
+    public withAccountCreationAPI(status: boolean): CFToolsClientBuilder {
+        this.hasAccountCreationAccess = status;
+        if (this.hasAccountCreationAccess && !this.enterpriseToken) {
+            throw new Error('Account creation API requires an Enterprise API access token');
+        }
         return this;
     }
 
@@ -112,7 +127,7 @@ export class CFToolsClientBuilder {
         } else {
             auth = new NoOpAuthorizationProvider();
         }
-        const client = new GotCFToolsClient(this.clientBuilder(auth), this.serverApiId, auth);
+        const client = new GotCFToolsClient(this.clientBuilder(auth), this.serverApiId, this.enterpriseToken, this.hasAccountCreationAccess, auth);
         if (this.cache !== undefined) {
             return new CachingCFToolsClient(this.cache, this.cacheConfig, client, this.serverApiId);
         }

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -88,7 +88,7 @@ interface RawAppGrants {
 export class GotCFToolsClient implements CFToolsClient {
     private readonly auth?: AuthorizationProvider;
 
-    constructor(private client: HttpClient, private serverApiId?: ServerApiId, private enterpriseToken?: string, private hasAccountCreationAccess?: boolean, auth?: AuthorizationProvider) {
+    constructor(private client: HttpClient, private serverApiId?: ServerApiId, private hasAccountCreationAccess?: boolean, auth?: AuthorizationProvider) {
         if (auth) {
             this.auth = auth;
         }
@@ -686,7 +686,6 @@ export class GotCFToolsClient implements CFToolsClient {
         }
 
         const requestUsesAccountCreation = this.hasAccountCreationAccess === true
-            && this.enterpriseToken !== undefined
             && playerId instanceof SteamId64;
 
         let response;

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -57,7 +57,6 @@ import {
     GetBanResponse,
     GetGameServerDetailsResponse,
     GetLeaderboardResponse,
-    GetPlayerLookupResponseWithNotice,
     GetPlayerResponse,
     GetPlayerResponsePlayer,
     GetPriorityQueueEntry,
@@ -704,7 +703,7 @@ export class GotCFToolsClient implements CFToolsClient {
             // Note: We could just apply the `create` param above, but this parameter is only ever
             // allowed when there is no existing user with the supplied identity token.
             if (requestUsesAccountCreation) {
-                response = await this.client.get<GetPlayerLookupResponseWithNotice>('v1/users/lookup', {
+                response = await this.client.get<GetUserLookupResponse>('v1/users/lookup', {
                     searchParams: {
                         identifier: playerId.id,
                         create: true,
@@ -714,7 +713,7 @@ export class GotCFToolsClient implements CFToolsClient {
                     },
                 });
                 if (response.notice !== 'Account Creation API account created') {
-                    throw new AccountCreationFailed(playerId.id, response.notice);
+                    throw new AccountCreationFailed(playerId.id, response.notice ?? 'Unknown error');
                 }
             }
             else {

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -85,10 +85,22 @@ interface RawAppGrants {
     };
 }
 
+interface ResolveRequestOptions {
+    /**
+     * The CFTools Enterprise API comes with special endpoint parameter for `/v1/users/resolve` (`client#resolve`), which allows to
+     * create a new CFTools account for an identity token that has never played on a CFTools Cloud-enabled server before.
+     * This functionality is not available to everyone with an Enterprise API token, but requires explicit access by CFTools.
+     * This parameter allows to enable this functionality.
+     * @throws AccountCreationFailed if the account creation failed.
+     * @throws A generic API error if you enable this without having the required permissions obtained by CFTools.
+     */
+    autoCreateAccount?: boolean;
+}
+
 export class GotCFToolsClient implements CFToolsClient {
     private readonly auth?: AuthorizationProvider;
 
-    constructor(private client: HttpClient, private serverApiId?: ServerApiId, private hasAccountCreationAccess?: boolean, auth?: AuthorizationProvider) {
+    constructor(private client: HttpClient, private serverApiId?: ServerApiId, auth?: AuthorizationProvider) {
         if (auth) {
             this.auth = auth;
         }
@@ -674,7 +686,7 @@ export class GotCFToolsClient implements CFToolsClient {
         }
     }
 
-    async resolve(id: GenericId | { playerId: GenericId }): Promise<CFToolsId> {
+    async resolve(id: GenericId | { playerId: GenericId }, requestOptions?: ResolveRequestOptions): Promise<CFToolsId> {
         let playerId: GenericId;
         if ('playerId' in id) {
             playerId = id.playerId;
@@ -685,7 +697,7 @@ export class GotCFToolsClient implements CFToolsClient {
             return playerId;
         }
 
-        const requestUsesAccountCreation = this.hasAccountCreationAccess === true
+        const requestUsesAccountCreation = requestOptions?.autoCreateAccount === true
             && playerId instanceof SteamId64;
 
         let response;

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -675,7 +675,6 @@ export class GotCFToolsClient implements CFToolsClient {
         }
     }
 
-    async resolve(id: GenericId | { playerId: GenericId }): Promise<CFToolsId>
     async resolve(id: GenericId | { playerId: GenericId }): Promise<CFToolsId> {
         let playerId: GenericId;
         if ('playerId' in id) {

--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -85,6 +85,10 @@ interface RawAppGrants {
     };
 }
 
+/**
+ * Options to use when resolving a generic player identifier to a CFTools ID. This method is used throughout
+ * the SDK to resolve identifiers to CFTools IDs for other available methods.
+ */
 interface ResolveRequestOptions {
     /**
      * The CFTools Enterprise API comes with special endpoint parameter for `/v1/users/resolve` (`client#resolve`), which allows to
@@ -127,9 +131,9 @@ export class GotCFToolsClient implements CFToolsClient {
         }
     }
 
-    async getPlayerDetails(playerId: GetPlayerDetailsRequest | GenericId): Promise<Player> {
+    async getPlayerDetails(playerId: GetPlayerDetailsRequest | GenericId, resolveOptions?: ResolveRequestOptions): Promise<Player> {
         this.assertAuthentication();
-        const id = await this.resolve(playerId);
+        const id = await this.resolve(playerId, resolveOptions);
         const response = await this.client.get<GetPlayerResponse>(
             `v2/server/${this.resolveServerApiId('serverApiId' in playerId ? playerId : undefined).id}/player`,
             {
@@ -187,9 +191,9 @@ export class GotCFToolsClient implements CFToolsClient {
         };
     }
 
-    async deletePlayerDetails(id: GenericId | DeletePlayerDetailsRequest): Promise<void> {
+    async deletePlayerDetails(id: GenericId | DeletePlayerDetailsRequest, resolveOptions?: ResolveRequestOptions): Promise<void> {
         this.assertAuthentication();
-        const cftoolsId = await this.resolve(id);
+        const cftoolsId = await this.resolve(id, resolveOptions);
         await this.client.delete(`v2/server/${this.resolveServerApiId('serverApiId' in id ? id : undefined).id}/player`, {
             searchParams: {
                 cftools_id: cftoolsId.id,
@@ -236,9 +240,9 @@ export class GotCFToolsClient implements CFToolsClient {
         });
     }
 
-    async getPriorityQueue(playerId: GetPriorityQueueRequest | GenericId): Promise<PriorityQueueItem | null> {
+    async getPriorityQueue(playerId: GetPriorityQueueRequest | GenericId, resolveOptions?: ResolveRequestOptions): Promise<PriorityQueueItem | null> {
         this.assertAuthentication();
-        const id = await this.resolve(playerId);
+        const id = await this.resolve(playerId, resolveOptions);
         const response = await this.client.get<GetPriorityQueueEntry>(`v1/server/${this.resolveServerApiId('serverApiId' in playerId ? playerId : undefined).id}/queuepriority`, {
             searchParams: {
                 cftools_id: id.id,
@@ -259,9 +263,9 @@ export class GotCFToolsClient implements CFToolsClient {
         } as PriorityQueueItem;
     }
 
-    async putPriorityQueue(request: PutPriorityQueueItemRequest): Promise<void> {
+    async putPriorityQueue(request: PutPriorityQueueItemRequest, resolveOptions?: ResolveRequestOptions): Promise<void> {
         this.assertAuthentication();
-        const id = await this.resolve(request.id);
+        const id = await this.resolve(request.id, resolveOptions);
         const requestBody: any = {
             cftools_id: id.id,
             comment: request.comment,
@@ -277,9 +281,9 @@ export class GotCFToolsClient implements CFToolsClient {
         });
     }
 
-    async deletePriorityQueue(playerId: DeletePriorityQueueRequest | GenericId): Promise<void> {
+    async deletePriorityQueue(playerId: DeletePriorityQueueRequest | GenericId, resolveOptions?: ResolveRequestOptions): Promise<void> {
         this.assertAuthentication();
-        const id = await this.resolve(playerId);
+        const id = await this.resolve(playerId, resolveOptions);
         await this.client.delete(`v1/server/${this.resolveServerApiId('serverApiId' in playerId ? playerId : undefined).id}/queuepriority`, {
             searchParams: {
                 cftools_id: id.id
@@ -290,9 +294,9 @@ export class GotCFToolsClient implements CFToolsClient {
         });
     }
 
-    async getWhitelist(playerId: GetWhitelistRequest | GenericId): Promise<WhitelistItem | null> {
+    async getWhitelist(playerId: GetWhitelistRequest | GenericId, resolveOptions?: ResolveRequestOptions): Promise<WhitelistItem | null> {
         this.assertAuthentication();
-        const id = await this.resolve(playerId);
+        const id = await this.resolve(playerId, resolveOptions);
         const response = await this.client.get<GetPriorityQueueEntry>(`v1/server/${this.resolveServerApiId('serverApiId' in playerId ? playerId : undefined).id}/whitelist`, {
             searchParams: {
                 cftools_id: id.id,
@@ -313,9 +317,9 @@ export class GotCFToolsClient implements CFToolsClient {
         } as WhitelistItem;
     }
 
-    async putWhitelist(request: PutWhitelistItemRequest): Promise<void> {
+    async putWhitelist(request: PutWhitelistItemRequest, resolveOptions?: ResolveRequestOptions): Promise<void> {
         this.assertAuthentication();
-        const id = await this.resolve(request.id);
+        const id = await this.resolve(request.id, resolveOptions);
         const requestBody: any = {
             cftools_id: id.id,
             comment: request.comment,
@@ -331,9 +335,9 @@ export class GotCFToolsClient implements CFToolsClient {
         });
     }
 
-    async deleteWhitelist(playerId: DeleteWhitelistRequest | GenericId): Promise<void> {
+    async deleteWhitelist(playerId: DeleteWhitelistRequest | GenericId, resolveOptions?: ResolveRequestOptions): Promise<void> {
         this.assertAuthentication();
-        const id = await this.resolve(playerId);
+        const id = await this.resolve(playerId, resolveOptions);
         await this.client.delete(`v1/server/${this.resolveServerApiId('serverApiId' in playerId ? playerId : undefined).id}/whitelist`, {
             searchParams: {
                 cftools_id: id.id
@@ -597,10 +601,10 @@ export class GotCFToolsClient implements CFToolsClient {
         await this.gameLabsAction(body);
     }
 
-    async listBans(request: ListBansRequest): Promise<Ban[]> {
+    async listBans(request: ListBansRequest, resolveOptions?: ResolveRequestOptions): Promise<Ban[]> {
         let playerId: GenericId = request.playerId;
         if (!isIpAddress(request.playerId)) {
-            playerId = (await this.resolve(request))
+            playerId = (await this.resolve(request, resolveOptions))
         }
         const response = await this.client.get<GetBanResponse>(`v1/banlist/${request.list.id}/bans`, {
             searchParams: {
@@ -624,7 +628,7 @@ export class GotCFToolsClient implements CFToolsClient {
         });
     }
 
-    async putBan(request: PutBanRequest): Promise<void> {
+    async putBan(request: PutBanRequest, resolveOptions?: ResolveRequestOptions): Promise<void> {
         const requestBody: any = {
             reason: request.reason,
         };
@@ -633,7 +637,7 @@ export class GotCFToolsClient implements CFToolsClient {
             requestBody.identifier = id.id;
             requestBody.format = 'ipv4';
         } else {
-            requestBody.identifier = (await this.resolve({playerId: request.playerId})).id;
+            requestBody.identifier = (await this.resolve({playerId: request.playerId}, resolveOptions)).id;
             requestBody.format = 'cftools_id';
         }
         if (request.expiration && request.expiration !== 'Permanent') {

--- a/src/internal/got/types.ts
+++ b/src/internal/got/types.ts
@@ -83,10 +83,7 @@ export interface GetPlayerResponse {
 
 export interface GetUserLookupResponse {
     cftools_id: string,
-}
-
-export interface GetPlayerLookupResponseWithNotice extends GetUserLookupResponse {
-    notice: string;
+    notice?: string,
 }
 
 export interface GetLeaderboardResponse {

--- a/src/internal/got/types.ts
+++ b/src/internal/got/types.ts
@@ -85,6 +85,10 @@ export interface GetUserLookupResponse {
     cftools_id: string,
 }
 
+export interface GetPlayerLookupResponseWithNotice extends GetUserLookupResponse {
+    notice: string;
+}
+
 export interface GetLeaderboardResponse {
     leaderboard: {
         cftools_id: string,

--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -1,10 +1,11 @@
 import got, {Got, Headers, Hooks, HTTPError, Response} from 'got';
 import {
+    AccountCreationFailed,
     Authorization,
     AuthorizationProvider,
     CFToolsUnavailable,
     DuplicateResourceCreation,
-    GrantRequired,
+    GrantRequired, RequestForbidden,
     RequestLimitExceeded,
     ResourceNotConfigured,
     ResourceNotFound,
@@ -130,6 +131,12 @@ export function fromHttpError(error: HTTPError, auth?: Authorization): Error | H
     }
     if (response.statusCode === 403 && errorMessage(response) === 'expired-token') {
         return auth!!.throwExpired(error.request.requestUrl);
+    }
+    if (response.statusCode === 403 && errorMessage(response) === 'expired-token') {
+        return auth!!.throwExpired(error.request.requestUrl);
+    }
+    if (response.statusCode === 403) {
+        return new RequestForbidden(errorMessage(response));
     }
     if (response.statusCode === 500 && errorMessage(response) === 'unexpected-error') {
         return new UnknownError(error.request.requestUrl, JSON.parse(response.body as string).request_id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface CFToolsClient {
      *
      * This request requires an authenticated client.
      */
-    getPlayerDetails(id: GenericId | GetPlayerDetailsRequest): Promise<Player>
+    getPlayerDetails(id: GenericId | GetPlayerDetailsRequest, resolveOptions?: ResolveRequestOptions): Promise<Player>
 
     /**
      * Deletes the player details of the requested player. This will remove all information about the player from the
@@ -20,7 +20,7 @@ export interface CFToolsClient {
      * 
      * This request requires an authenticated client.
      */
-    deletePlayerDetails(id: GenericId | DeletePlayerDetailsRequest): Promise<void>
+    deletePlayerDetails(id: GenericId | DeletePlayerDetailsRequest, resolveOptions?: ResolveRequestOptions): Promise<void>
 
     /**
      * Creates a leaderboard based on the requested statistic in the requested order.
@@ -36,7 +36,7 @@ export interface CFToolsClient {
      *
      * This request requires an authenticated client.
      */
-    getPriorityQueue(id: GenericId | GetPriorityQueueRequest): Promise<PriorityQueueItem | null>
+    getPriorityQueue(id: GenericId | GetPriorityQueueRequest, resolveOptions?: ResolveRequestOptions): Promise<PriorityQueueItem | null>
 
     /**
      * Creates a priority queue entry for the given player. The entry will grant the player either permanent or
@@ -45,7 +45,7 @@ export interface CFToolsClient {
      *
      * This request requires an authenticated client.
      */
-    putPriorityQueue(request: PutPriorityQueueItemRequest): Promise<void>
+    putPriorityQueue(request: PutPriorityQueueItemRequest, resolveOptions?: ResolveRequestOptions): Promise<void>
 
     /**
      * Drops the priority queue of the player if the player has a priority queue entry for the server. Does not error
@@ -53,7 +53,7 @@ export interface CFToolsClient {
      *
      * This request requires an authenticated client.
      */
-    deletePriorityQueue(id: GenericId | DeletePriorityQueueRequest): Promise<void>
+    deletePriorityQueue(id: GenericId | DeletePriorityQueueRequest, resolveOptions?: ResolveRequestOptions): Promise<void>
 
     /**
      * Returns the meta information of the whitelist entry of the player. If the player does
@@ -61,7 +61,7 @@ export interface CFToolsClient {
      *
      * This request requires an authenticated client.
      */
-    getWhitelist(id: GenericId | GetWhitelistRequest): Promise<WhitelistItem | null>
+    getWhitelist(id: GenericId | GetWhitelistRequest, resolveOptions?: ResolveRequestOptions): Promise<WhitelistItem | null>
 
     /**
      * Creates a whitelist entry for the given player. If the player already has a whitelist entry,
@@ -69,7 +69,7 @@ export interface CFToolsClient {
      *
      * This request requires an authenticated client.
      */
-    putWhitelist(request: PutWhitelistItemRequest): Promise<void>
+    putWhitelist(request: PutWhitelistItemRequest, resolveOptions?: ResolveRequestOptions): Promise<void>
 
     /**
      * Drops the whitelist entry of the player if the player has a whitelist entry for the server. Does not error
@@ -77,7 +77,7 @@ export interface CFToolsClient {
      *
      * This request requires an authenticated client.
      */
-    deleteWhitelist(id: GenericId | DeleteWhitelistRequest): Promise<void>
+    deleteWhitelist(id: GenericId | DeleteWhitelistRequest, resolveOptions?: ResolveRequestOptions): Promise<void>
 
     /**
      * Return information about a specific game server instance. These information are not related to a specific
@@ -145,13 +145,13 @@ export interface CFToolsClient {
      *
      * If the requested user is not and was never banned so far, an empty list is returned.
      */
-    listBans(request: ListBansRequest): Promise<Ban[]>
+    listBans(request: ListBansRequest, resolveOptions?: ResolveRequestOptions): Promise<Ban[]>
 
     /**
      * Creates a new entry in the banlist for the provided player. A reason is required to ban a player. It is either
      * a temporary or permanent ban, based on the provided expiration.
      */
-    putBan(request: PutBanRequest): Promise<void>
+    putBan(request: PutBanRequest, resolveOptions?: ResolveRequestOptions): Promise<void>
 
     /**
      * Deletes an entry on the ban list for the provided player or ban. Given the player is not banned, this method
@@ -159,7 +159,7 @@ export interface CFToolsClient {
      * providing the ban you want to delete (as requested with the listBans method).
      *
      * This method will delete the ban, instead of just revoking it. The ban details will not be available in the
-     * banlist afterwards anymore.
+     * banlist afterward anymore.
      */
     deleteBan(request: DeleteBanRequest): Promise<void>
 
@@ -180,7 +180,24 @@ export interface CFToolsClient {
      * Resolves the CFToolsId of the passed in players generic ID (e.g. a Steam ID, BE GUID or alike). The CFToolsId
      * returned identifies the same player as the passed in generic ID.
      */
-    resolve(id: GenericId | { playerId: GenericId }): Promise<CFToolsId>
+    resolve(id: GenericId | { playerId: GenericId }, resolveOptions?: ResolveRequestOptions): Promise<CFToolsId>
+}
+
+/**
+ * Request options for a request to resolve a player ID to a CFTools ID.
+ */
+export interface ResolveRequestOptions {
+    /**
+     * The CFTools Enterprise API allows a caller to automatically create a CFTools account for a SteamID64, which
+     * never connected to a CFTools-enabled server. Hence, a user account for this SteamID64 does not yet exist.
+     *
+     * Requires a CFToolsClient with an enterprise authorization setup, otherwise the request fails with a
+     * RequestForbidden error.
+     *
+     * @throws AccountCreationFailed if the account creation failed.
+     * @throws RequestForbidden if the request is forbidden (no Enterprise account, e.g.).
+     */
+    autoCreateAccount?: boolean;
 }
 
 export interface Cache {
@@ -967,6 +984,18 @@ export class GrantRequired extends Error {
     constructor(url: string) {
         super('GrantRequired: ' + url);
         Object.setPrototypeOf(this, GrantRequired.prototype);
+    }
+}
+
+/**
+ * A generic error indicating that a request was rejected because the client is not allowed to either access the requested
+ * resource, execute the requested action or alike.
+ * More details might be available in the #message property, if the API provided it.
+ */
+export class RequestForbidden extends Error {
+    constructor(public readonly message: string) {
+        super('RequestForbidden: ' + message);
+        Object.setPrototypeOf(this, RequestForbidden.prototype);
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -844,6 +844,16 @@ export class ResourceNotFound extends Error {
 }
 
 /**
+ * Indicates that an account could not be created through the Account Creation API using the provided identity token.
+ */
+export class AccountCreationFailed extends Error {
+    constructor(identityToken: string, notice: string) {
+        super('AccountCreationFailed: ' + identityToken + ' (' + notice + ')');
+        Object.setPrototypeOf(this, AccountCreationFailed.prototype);
+    }
+}
+
+/**
  * Indicates that the requested resource was found, however, the action on it could not be fulfilled as the required
  * bucket (like queuepriority or whitelist) was not configured on this resource. You should only retry this request
  * when you ensured that the respective bucket is now configured for the resource correctly.


### PR DESCRIPTION
This Pull Request implements support for the Account Creation API, which is built on top of the `v1/users/lookup` endpoint.

I would like to request you to look further into the [error handler](https://github.com/FlorianSW/cftools-sdk/pull/15/files#diff-dc3bab5e8f385c8749856e8d81bdfb65df2103c0cd2d73f14323a324222dbe22R704-R724), as we should be checking if the error is a `ResourceNotFound` error, and I'm also not sure this `catch` logic should be in here, or if it should be handled in your `withErrorHandler` wrapper.

Feel free to remove my [note](https://github.com/FlorianSW/cftools-sdk/pull/15/files#diff-dc3bab5e8f385c8749856e8d81bdfb65df2103c0cd2d73f14323a324222dbe22R705-R706) if needed, I just figured it would be useful information for any future (refactor) contributions.