### PR TITLE
feat: Add firstSeen and lastSeen timestamps to Player details

### DIFF
--- a/src/internal/got/client.ts
+++ b/src/internal/got/client.ts
@@ -166,6 +166,8 @@ export class GotCFToolsClient implements CFToolsClient {
             },
             playtime: player.omega.playtime,
             sessions: player.omega.sessions,
+            firstSeen: new Date(player.created_at),
+            lastSeen: new Date(player.updated_at),
             identities: {
                 battleye: BattlEyeGUID.of(identities.battleye.guid),
                 bohemia: BohemiaInteractiveId.of(identities.bohemiainteractive.uid),

--- a/src/internal/got/types.ts
+++ b/src/internal/got/types.ts
@@ -67,6 +67,8 @@ export interface GetPlayerResponsePlayer {
             zones: GetPlayerResponseHitZones,
         }
     },
+    created_at: Date,
+    updated_at: Date
 }
 
 export interface GetPlayerResponseIdentities {

--- a/src/types.ts
+++ b/src/types.ts
@@ -505,6 +505,8 @@ export interface Player {
      */
     playtime: number,
     sessions: number,
+    firstSeen: Date,
+    lastSeen: Date,
 }
 
 export interface DayZStatistics {


### PR DESCRIPTION
**Description:** This PR exposes the `created_at` and `updated_at` fields from the API response, mapping them to `firstSeen` and `lastSeen` in the Player interface.

**Motivation:** Currently, relying on `playtime` or `sessions` to determine if a player is "new" is unreliable because these values are cleared during statistic resets (server wipes). The `firstSeen` (account creation) date persists across resets, allowing developers to distinguish between a fresh player and an existing player after a wipe.

**Changes:**
Updated `GetPlayerResponsePlayer` interface to reflect raw API string types.
Added `firstSeen` and `lastSeen` (as `Date` objects) to the returned `Player` structure.
Implemented proper string-to-Date parsing in `getPlayerDetails`.